### PR TITLE
v0.3 extended for FTM1 and FTM2

### DIFF
--- a/FreqMeasureMulti.cpp
+++ b/FreqMeasureMulti.cpp
@@ -33,9 +33,9 @@
 #define UPDATE_ON_FALLING 2
 #define UPDATE_DIFFERENCE 4
 
-static uint8_t channelmask = 0;
-static uint16_t capture_msw = 0;
-static FreqMeasureMulti * list[8];
+static uint8_t channelmask[4] = {0, 0, 0, 0};
+static uint16_t capture_msw[4] = {0, 0, 0, 0};
+static FreqMeasureMulti * list[4][8];
 
 bool FreqMeasureMulti::begin(uint32_t pin) {
 	return begin(pin, FREQMEASUREMULTI_RAISING);
@@ -44,16 +44,21 @@ bool FreqMeasureMulti::begin(uint32_t pin) {
 bool FreqMeasureMulti::begin(uint32_t pin, uint8_t mode)
 {
 	uint8_t capture_mode;
+	Serial.print("PIN: ");Serial.print(pin);Serial.print(" - Mode: "); Serial.println(mode);
 	switch (pin) {
-		case 22: channel = 0; CORE_PIN22_CONFIG = PORT_PCR_MUX(4); break;
-		case 23: channel = 1; CORE_PIN23_CONFIG = PORT_PCR_MUX(4); break;
-		case  9: channel = 2; CORE_PIN9_CONFIG  = PORT_PCR_MUX(4); break;
-		case 10: channel = 3; CORE_PIN10_CONFIG = PORT_PCR_MUX(4); break;
-		case  6: channel = 4; CORE_PIN6_CONFIG  = PORT_PCR_MUX(4); break;
-		case 20: channel = 5; CORE_PIN20_CONFIG = PORT_PCR_MUX(4); break;
+		case 22: channel = 0; ftm=0; CORE_PIN22_CONFIG = PORT_PCR_MUX(4); break;
+		case 23: channel = 1; ftm=0; CORE_PIN23_CONFIG = PORT_PCR_MUX(4); break;
+		case  9: channel = 2; ftm=0; CORE_PIN9_CONFIG  = PORT_PCR_MUX(4); break;
+		case 10: channel = 3; ftm=0; CORE_PIN10_CONFIG = PORT_PCR_MUX(4); break;
+		case  6: channel = 4; ftm=0; CORE_PIN6_CONFIG  = PORT_PCR_MUX(4); break;
+		case 20: channel = 5; ftm=0; CORE_PIN20_CONFIG = PORT_PCR_MUX(4); break;
+		case  3: channel = 0; ftm=1; CORE_PIN3_CONFIG = PORT_PCR_MUX(3); break;
+		case  4: channel = 1; ftm=1; CORE_PIN4_CONFIG = PORT_PCR_MUX(3); break;
 #if defined(KINETISK)
-		case 21: channel = 6; CORE_PIN21_CONFIG = PORT_PCR_MUX(4); break;
-		case  5: channel = 7; CORE_PIN5_CONFIG  = PORT_PCR_MUX(4); break;
+		case 21: channel = 6; ftm=0; CORE_PIN21_CONFIG = PORT_PCR_MUX(4); break;
+		case  5: channel = 7; ftm=0; CORE_PIN5_CONFIG  = PORT_PCR_MUX(4); break;
+		case 32: channel = 0; ftm=2; CORE_PIN32_CONFIG  = PORT_PCR_MUX(3); break;
+		case 25: channel = 1; ftm=2; CORE_PIN25_CONFIG = PORT_PCR_MUX(3); break;
 #endif
 		default:
 			channel = 8;
@@ -74,35 +79,78 @@ bool FreqMeasureMulti::begin(uint32_t pin, uint8_t mode)
 	act_on_fall = (capture_mode & UPDATE_ON_FALLING);
 	read_diff = (capture_mode & UPDATE_DIFFERENCE);
 
-	NVIC_DISABLE_IRQ(IRQ_FTM0);
-	if (FTM0_MOD != 0xFFFF || (FTM0_SC & 0x7F) != FTM_SC_VALUE) {
-		FTM0_SC = 0;
-		FTM0_CNT = 0;
-		FTM0_MOD = 0xFFFF;
-		FTM0_SC = FTM_SC_VALUE;
-		#ifdef KINETISK
-		FTM0_MODE = FTM_MODE_WPDIS; //allow reconfiguring the CSC on the fly
+	switch(ftm) {
+	/* To do: add MK6x FTM3 support */
+	case 0:
+		NVIC_DISABLE_IRQ(IRQ_FTM0);
+		if (FTM0_MOD != 0xFFFF || (FTM0_SC & 0x7F) != FTM_SC_VALUE) {
+			FTM0_SC = 0;
+			FTM0_CNT = 0;
+			FTM0_MOD = 0xFFFF;
+			FTM0_SC = FTM_SC_VALUE;
+			#ifdef KINETISK
+			FTM0_MODE = FTM_MODE_WPDIS; //allow reconfiguring the CSC on the fly
+			#endif
+		}
+		csc = &FTM0_C0SC + channel * 2;
+		#if defined(KINETISL)
+		*csc = 0;
+		delayMicroseconds(1);
 		#endif
+		NVIC_SET_PRIORITY(IRQ_FTM0, 48);
+		break;
+	case 1:
+		NVIC_DISABLE_IRQ(IRQ_FTM1);
+		if (FTM1_MOD != 0xFFFF || (FTM1_SC & 0x7F) != FTM_SC_VALUE) {
+			FTM1_SC = 0;
+			FTM1_CNT = 0;
+			FTM1_MOD = 0xFFFF;
+			FTM1_SC = FTM_SC_VALUE;
+			#ifdef KINETISK
+			FTM1_MODE = FTM_MODE_WPDIS; //allow reconfiguring the CSC on the fly
+			#endif
+		}
+		csc = &FTM1_C0SC + channel * 2;
+		#if defined(KINETISL)
+		*csc = 0;
+		delayMicroseconds(1);
+		#endif
+		NVIC_SET_PRIORITY(IRQ_FTM1, 48);
+		break;
+	case 2:
+		NVIC_DISABLE_IRQ(IRQ_FTM2);
+		if (FTM2_MOD != 0xFFFF || (FTM2_SC & 0x7F) != FTM_SC_VALUE) {
+			FTM2_SC = 0;
+			FTM2_CNT = 0;
+			FTM2_MOD = 0xFFFF;
+			FTM2_SC = FTM_SC_VALUE;
+			FTM2_MODE = FTM_MODE_WPDIS; //allow reconfiguring the CSC on the fly
+		}
+		csc = &FTM2_C0SC + channel * 2;
+		NVIC_SET_PRIORITY(IRQ_FTM2, 48);
+		break;
 	}
-
-	capture_msw = 0;
+	capture_msw[ftm] = 0;
 	raiscap_previous = 0;
 	fallcap_previous = 0;
 	next_is_falling = false;
 	buffer_head = 0;
 	buffer_tail = 0;
 
-	volatile uint32_t *csc = &FTM0_C0SC + channel * 2;
-	#if defined(KINETISL)
-	*csc = 0;
-	delayMicroseconds(1);
-	#endif
 	*csc = FTM_CSC_RAISING; // first capture is always rising
 
-	list[channel] = this;
-	channelmask |= (1 << channel);
-	NVIC_SET_PRIORITY(IRQ_FTM0, 48);
-	NVIC_ENABLE_IRQ(IRQ_FTM0);
+	list[ftm][channel] = this;
+	channelmask[ftm] |= (1 << channel);
+	switch (ftm) {
+	case 0:
+		NVIC_ENABLE_IRQ(IRQ_FTM0); break;
+	case 1:
+		NVIC_ENABLE_IRQ(IRQ_FTM1); break;
+	case 2:
+		NVIC_ENABLE_IRQ(IRQ_FTM2); break;
+/* To do: add MK6x FTM3 support */
+	}
+	Serial.print("FTM: ");Serial.print(ftm);Serial.print(" - Channel: "); Serial.println(channel);
 	return true;
 }
 
@@ -156,21 +204,37 @@ float FreqMeasureMulti::countToNanoseconds(uint32_t count)
 
 void FreqMeasureMulti::end(void)
 {
-	switch (channel) {
-		case 0: CORE_PIN22_CONFIG = 0; break;
-		case 1: CORE_PIN23_CONFIG = 0; break;
-		case 2: CORE_PIN9_CONFIG  = 0; break;
-		case 3: CORE_PIN10_CONFIG = 0; break;
-		case 4: CORE_PIN6_CONFIG  = 0; break;
-		case 5: CORE_PIN20_CONFIG = 0; break;
+	switch (ftm) {
+		case 0:
+			switch (channel) {
+			case 0: CORE_PIN22_CONFIG = 0; break;
+			case 1: CORE_PIN23_CONFIG = 0; break;
+			case 2: CORE_PIN9_CONFIG  = 0; break;
+			case 3: CORE_PIN10_CONFIG = 0; break;
+			case 4: CORE_PIN6_CONFIG  = 0; break;
+			case 5: CORE_PIN20_CONFIG = 0; break;
 #if defined(KINETISK)
-		case 6: CORE_PIN21_CONFIG = 0; break;
-		case 7: CORE_PIN5_CONFIG  = 0; break;
+			case 6: CORE_PIN21_CONFIG = 0; break;
+			case 7: CORE_PIN5_CONFIG  = 0; break;
 #endif
-		default: return;
-	}
-	channelmask &= ~(1 << channel);
-	volatile uint32_t *csc = &FTM0_C0SC + channel * 2;
+			default: return;
+			} break;
+		case 1:
+			switch (channel) {
+			case 0: CORE_PIN3_CONFIG = 0; break;
+			case 1: CORE_PIN4_CONFIG = 0; break;
+			default: return;
+			} break;
+#if defined(KINETISK)
+		case 2:
+			switch (channel) {
+			case 0: CORE_PIN32_CONFIG = 0; break;
+			case 1: CORE_PIN25_CONFIG = 0; break;
+			default: return;
+			} break;
+#endif
+		}
+	channelmask[ftm] &= ~(1 << channel);
 	*csc = 0;
 }
 
@@ -183,27 +247,57 @@ void ftm0_isr(void)
 		#elif defined(KINETISL)
 		FTM0_SC = FTM_SC_VALUE | FTM_SC_TOF;
 		#endif
-		capture_msw++;
+		capture_msw[0]++;
 		inc = true;
 	}
-	uint8_t mask = FTM0_STATUS & channelmask;
-	if ((mask & 0x01)) list[0]->isr(inc);
-	if ((mask & 0x02)) list[1]->isr(inc);
-	if ((mask & 0x04)) list[2]->isr(inc);
-	if ((mask & 0x08)) list[3]->isr(inc);
-	if ((mask & 0x10)) list[4]->isr(inc);
-	if ((mask & 0x20)) list[5]->isr(inc);
+	uint8_t mask = FTM0_STATUS & channelmask[0];
+	if ((mask & 0x01)) list[0][0]->isr(inc);
+	if ((mask & 0x02)) list[0][1]->isr(inc);
+	if ((mask & 0x04)) list[0][2]->isr(inc);
+	if ((mask & 0x08)) list[0][3]->isr(inc);
+	if ((mask & 0x10)) list[0][4]->isr(inc);
+	if ((mask & 0x20)) list[0][5]->isr(inc);
 	#if defined(KINETISK)
-	if ((mask & 0x40)) list[6]->isr(inc);
-	if ((mask & 0x80)) list[7]->isr(inc);
+	if ((mask & 0x40)) list[0][6]->isr(inc);
+	if ((mask & 0x80)) list[0][7]->isr(inc);
 	#endif
+}
+
+void ftm1_isr(void)
+{
+	bool inc = false;
+	if (FTM1_SC & FTM_SC_TOF) {
+		#if defined(KINETISK)
+		FTM1_SC = FTM_SC_VALUE;
+		#elif defined(KINETISL)
+		FTM1_SC = FTM_SC_VALUE | FTM_SC_TOF;
+		#endif
+		capture_msw[1]++;
+		inc = true;
+	}
+	uint8_t mask = FTM1_STATUS & channelmask[1];
+//	Serial.println(FTM1_STATUS);//
+	if ((mask & 0x01)) list[1][0]->isr(inc);
+	if ((mask & 0x02)) list[1][1]->isr(inc);
+}
+
+void ftm2_isr(void)
+{
+	bool inc = false;
+	if (FTM2_SC & FTM_SC_TOF) {
+		FTM2_SC = FTM_SC_VALUE;
+		capture_msw[2]++;
+		inc = true;
+	}
+	uint8_t mask = FTM2_STATUS & channelmask[2];
+	if ((mask & 0x01)) list[2][0]->isr(inc);
+	if ((mask & 0x02)) list[2][1]->isr(inc);
 }
 
 void FreqMeasureMulti::isr(bool inc)
 {
 	uint32_t period = 0;
 	uint8_t level = LEVEL_UNDEFINED;
-	volatile uint32_t *csc = &FTM0_C0SC + channel * 2;
 	uint32_t capture = csc[1];
 	next_is_falling = !next_is_falling; // toggle capture mode
 	#if defined(KINETISK)
@@ -212,9 +306,9 @@ void FreqMeasureMulti::isr(bool inc)
 	csc[0] = (next_is_falling ? FTM_CSC_FALLING : FTM_CSC_RAISING) | FTM_CSC_CHF;
 	#endif
 	if (capture <= 0xE000 || !inc) {
-		capture |= (capture_msw << 16);
+		capture |= (capture_msw[ftm] << 16);
 	} else {
-		capture |= ((capture_msw - 1) << 16);
+		capture |= ((capture_msw[ftm] - 1) << 16);
 	}
 	// compute the waveform period
 	if (next_is_falling) {

--- a/FreqMeasureMulti.h
+++ b/FreqMeasureMulti.h
@@ -36,11 +36,15 @@ public:
 	void end(void);
 private:
 	void isr(bool inc);
+	volatile uint32_t *csc = 0;
 	friend void ftm0_isr(void);
+	friend void ftm1_isr(void);
+	friend void ftm2_isr(void);
 	fmultiRecord buffer_value[FREQMEASUREMULTI_BUFFER_LEN];
 	uint8_t buffer_head;
 	uint8_t buffer_tail;
 	uint8_t channel;
+	uint8_t ftm;
 	uint8_t last_read_level;
 	uint32_t raiscap_previous;
 	uint32_t fallcap_previous;

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 #FreqMeasureMulti Library#
 
-FreqMeasureMulti basically measures the elapsed time during each cycle of an input frequency, that means the number of timer ticks between a raising ramp of the input signal and the next. Extended capture modes which allow a more detailed analysis of the input signal have been added in v0.2 (see below).
+FreqMeasureMulti basically measures the elapsed time during each cycle of an input frequency, that means the number of timer ticks between a raising ramp of the input signal and the next. Extended capture modes which allow a more detailed analysis of the input signal have been added in v0.2 (see below). v0.3 adds support for more pins, allowing either to capture up to 12 pulse streams simultaneously, or to use for example the FTM1 (3,4) and/or FTM2 (25,32) pins while keeping the often used FTM0 pins (5,6,9,10,20,21,22,23) free for GPIO or PWM use.
 
-Up to 8 frequencies can be measured simultaneously.
+Up to 12 frequencies can be measured simultaneously.
 
     Board            Supported Pins
     -----            --------------
-    Teensy LC        6, 9, 10, 20, 22, 23
-    Teensy 3.1       5, 6, 9, 10, 20, 21, 22, 23
-    Teensy 3.2       5, 6, 9, 10, 20, 21, 22, 23
+    Teensy LC        3, 4, 6, 9, 10, 20, 22, 23
+    Teensy 3.1       3, 4, 5, 6, 9, 10, 20, 21, 22, 23, 25, 32
+    Teensy 3.2       3, 4, 5, 6, 9, 10, 20, 21, 22, 23, 25, 32
 
 FreqMeasureMulti uses the same functions as FreqMeasure, except begin() must specify a pin number.  Because more than 1 input can be measured, you must create FreqMeasureMulti instances.  See the Serial_Output example.
 

--- a/keywords.txt
+++ b/keywords.txt
@@ -2,5 +2,7 @@ FreqMeasureMulti	KEYWORD1
 begin	KEYWORD2
 available	KEYWORD2
 read	KEYWORD2
+readLevel	KEYWORD2
 countToFrequency	KEYWORD2
+countToNanoseconds	KEYWORD2
 end	KEYWORD2

--- a/library.properties
+++ b/library.properties
@@ -1,8 +1,8 @@
 name=FreqMeasureMulti
-version=0.22
+version=0.3
 author=Paul Stoffregen, Thierry Frenkel
 maintainer=Paul Stoffregen
-sentence=FreqMeasureMulti measures up to 8 frequencies, simultaneously!  The elapsed time during each cycle is measured, which is best for signals under 5 kHz.
+sentence=FreqMeasureMulti measures up to 12 frequencies, simultaneously!  The elapsed time during each cycle is measured, which is best for signals under 5 kHz.
 paragraph=
 category=Signal Input/Output
 url=https://github.com/PaulStoffregen/FreqMeasureMulti


### PR DESCRIPTION
Allows to measure up to 12 frequencies or pulse streams, or simply to
keep the FTM0 pins free for PWM.
Details in README.md